### PR TITLE
Make map visible again with inline style

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -127,7 +127,7 @@
          
 
     <!--The div element for the map -->
-    <div id="map"></div>
+    <div id="map" style="height: 400px"></div>
     <script>
       // Initialize and add the map
     var map 


### PR DESCRIPTION
Directly hardcode map height as a style override on the div.

Attempted the following, but didn't work:
1. Specifying height in #map
2. Using HTML heighht="400" on the div